### PR TITLE
Fixed GSPA + holding component install failure

### DIFF
--- a/tnt/tnt.tp2
+++ b/tnt/tnt.tp2
@@ -529,7 +529,8 @@ GROUP @600 /* Assorted convenience components */
 REQUIRE_PREDICATE (GAME_INCLUDES ~bg1~ OR GAME_INCLUDES ~bg2~) @122 /* BG saga only */
 SUBCOMPONENT @610 /* Starting bags */
 ACTION_DEFINE_ARRAY bags BEGIN gem scr pot ammo hold END
-INCLUDE ~%components%/starting_bags/main.tpa~
+OUTER_SPRINT comp_name ~starting_bags~
+WITH_TRA ~%lang_dir%/%comp_name%.tra~ BEGIN INCLUDE ~%components%/starting_bags/main.tpa~ END
 
 BEGIN @613 /* GSPA + holding - all bottomless! */
 GROUP @600 /* Assorted convenience components */


### PR DESCRIPTION
I noticed an install failure for the GSPA + holding component, most likely it was just missed during a recent refactor.  I added in the missing lines and it installs properly now.  Tested on BGT and oBG2.